### PR TITLE
[pickers] Fix duplicate hour label in MultiSectionDigitalClock on DST day

### DIFF
--- a/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClock.tsx
+++ b/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClock.tsx
@@ -307,7 +307,6 @@ export const MultiSectionDigitalClock = React.forwardRef(function MultiSectionDi
               );
             },
             items: getHourSectionOptions({
-              now,
               value,
               ampm,
               adapter,

--- a/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClock.utils.ts
+++ b/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClock.utils.ts
@@ -2,7 +2,6 @@ import { MuiPickersAdapter, PickerValidDate } from '../models';
 import { MultiSectionDigitalClockOption } from './MultiSectionDigitalClock.types';
 
 interface GetHoursSectionOptionsParameters {
-  now: PickerValidDate;
   value: PickerValidDate | null;
   adapter: MuiPickersAdapter;
   ampm: boolean;
@@ -13,7 +12,6 @@ interface GetHoursSectionOptionsParameters {
 }
 
 export const getHourSectionOptions = ({
-  now,
   value,
   adapter,
   ampm,
@@ -49,10 +47,14 @@ export const getHourSectionOptions = ({
 
   const endHour = ampm ? 11 : 23;
   for (let hour = 0; hour <= endHour; hour += timeStep) {
-    let label = adapter.format(adapter.setHours(now, hour), ampm ? 'hours12h' : 'hours24h');
-    const ariaLabel = resolveAriaLabel(parseInt(label, 10).toString());
-
-    label = adapter.formatNumber(label);
+    // Compute the label from the loop index rather than from a concrete date.
+    // Going through `adapter.setHours(now, hour)` can return the "wrong" hour on a DST
+    // spring-forward day in some adapters (e.g. setting hours to 2 AM lands on 3 AM because
+    // 2 AM does not exist), which previously led to duplicate labels and a missing entry in
+    // the dropdown. See https://github.com/mui/mui-x/issues/21669.
+    const displayedHour = ampm && hour === 0 ? 12 : hour;
+    const ariaLabel = resolveAriaLabel(displayedHour.toString());
+    const label = adapter.formatNumber(displayedHour.toString().padStart(2, '0'));
 
     result.push({
       value: hour,

--- a/packages/x-date-pickers/src/MultiSectionDigitalClock/tests/timezone.MultiSectionDigitalClock.test.tsx
+++ b/packages/x-date-pickers/src/MultiSectionDigitalClock/tests/timezone.MultiSectionDigitalClock.test.tsx
@@ -1,0 +1,124 @@
+import { spy } from 'sinon';
+import { screen } from '@mui/internal-test-utils';
+import { MultiSectionDigitalClock } from '@mui/x-date-pickers/MultiSectionDigitalClock';
+import { createPickerRenderer, describeAdapters } from 'test/utils/pickers';
+
+describe('<MultiSectionDigitalClock /> - Timezone', () => {
+  describeAdapters(
+    'DST spring-forward handling',
+    MultiSectionDigitalClock,
+    ({ adapter, render }) => {
+      describe.skipIf(!adapter.isTimezoneCompatible)('timezoneCompatible', () => {
+        // On this day Chicago switches from CST (UTC-6) to CDT (UTC-5);
+        // local time jumps from 2:00 AM directly to 3:00 AM so 2 AM does not exist.
+        // Regression test for https://github.com/mui/mui-x/issues/21669 — labels for
+        // each hour should be computed independently of DST so there are no duplicates
+        // and no missing entries.
+        it('should render each 12-hour hour with a unique label on a spring-forward day', () => {
+          const value = adapter.date('2026-03-08T04:00:00', 'America/Chicago');
+
+          render(<MultiSectionDigitalClock defaultValue={value} timezone="America/Chicago" ampm />);
+
+          const hourOptionLabels = screen
+            .getAllByRole('option')
+            .filter((option) => option.getAttribute('aria-label')?.endsWith('hours'))
+            .map((option) => option.textContent);
+
+          expect(hourOptionLabels).to.have.length(12);
+          expect(new Set(hourOptionLabels).size).to.equal(12);
+          expect(hourOptionLabels).to.deep.equal([
+            '12',
+            '01',
+            '02',
+            '03',
+            '04',
+            '05',
+            '06',
+            '07',
+            '08',
+            '09',
+            '10',
+            '11',
+          ]);
+        });
+
+        it('should render each 24-hour hour with a unique label on a spring-forward day', () => {
+          const value = adapter.date('2026-03-08T04:00:00', 'America/Chicago');
+
+          render(
+            <MultiSectionDigitalClock
+              defaultValue={value}
+              timezone="America/Chicago"
+              ampm={false}
+            />,
+          );
+
+          const hourOptionLabels = screen
+            .getAllByRole('option')
+            .filter((option) => option.getAttribute('aria-label')?.endsWith('hours'))
+            .map((option) => option.textContent);
+
+          expect(hourOptionLabels).to.have.length(24);
+          expect(new Set(hourOptionLabels).size).to.equal(24);
+        });
+      });
+    },
+  );
+
+  describe('DST spring-forward handling with system clock on DST day', () => {
+    // Reproduces https://github.com/mui/mui-x/issues/21669 more faithfully: the
+    // adapter's internal `now` falls on the DST spring-forward day, which previously
+    // corrupted the hour labels derived from it.
+    const { render, adapter } = createPickerRenderer({
+      adapterName: 'dayjs',
+      clockConfig: new Date('2026-03-08T15:00:00.000Z'),
+    });
+
+    it('should render each 12-hour hour with a unique label', () => {
+      const value = adapter.date('2026-03-08T04:00:00', 'America/Chicago');
+
+      render(<MultiSectionDigitalClock defaultValue={value} timezone="America/Chicago" ampm />);
+
+      const hourOptionLabels = screen
+        .getAllByRole('option')
+        .filter((option) => option.getAttribute('aria-label')?.endsWith('hours'))
+        .map((option) => option.textContent);
+
+      expect(hourOptionLabels).to.have.length(12);
+      expect(new Set(hourOptionLabels).size).to.equal(12);
+      expect(hourOptionLabels).to.deep.equal([
+        '12',
+        '01',
+        '02',
+        '03',
+        '04',
+        '05',
+        '06',
+        '07',
+        '08',
+        '09',
+        '10',
+        '11',
+      ]);
+    });
+
+    it('should allow selecting 4 AM', async () => {
+      const onChange = spy();
+      const value = adapter.date('2026-03-08T03:00:00', 'America/Chicago');
+
+      const { user } = render(
+        <MultiSectionDigitalClock
+          defaultValue={value}
+          timezone="America/Chicago"
+          ampm
+          onChange={onChange}
+        />,
+      );
+
+      await user.click(screen.getByRole('option', { name: '4 hours' }));
+
+      expect(onChange.callCount).to.equal(1);
+      expect(adapter.getHours(onChange.lastCall.firstArg)).to.equal(4);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #21669 and #22084.

On a DST spring-forward day in timezones like `America/Chicago` or `America/Los_Angeles`, the `MultiSectionDigitalClock` hour column rendered `"03"` twice and omitted `"02"`. Combined with the v8 skipped-hour disable check, this showed up as a confusing picker where nearby hours (e.g. `"04"`) appeared unselectable.

**Root cause**: labels were produced via `adapter.format(adapter.setHours(now, hour), 'hours12h')`. On the DST day, `setHours(now, 2)` returns a date whose local hour is `3` (because 2 AM does not exist locally and the adapter rolls forward), so the label for `hour=2` came out as `"03"` — same label as `hour=3`, triggering a duplicate React key warning and a missing `"02"` row.

**Fix**: compute the label directly from the loop index rather than from a DST-affected date. `TimeClock`'s `getHourNumbers` already uses this approach. Since `now` is no longer needed, the parameter is removed from the internal `getHourSectionOptions` helper (not part of the public API).

Before (Mar 8 2026, Chicago timezone, LA system timezone):
```
12, 01, 03 (disabled), 03 (selected), 04, 05, ..., 11
```

After:
```
12, 01, 02 (disabled), 03 (selected), 04, 05, ..., 11
```

## Test plan

- [ ] Added `timezone.MultiSectionDigitalClock.test.tsx` with:
  - A `describeAdapters` pair asserting 12- and 24-hour columns have unique labels on the DST day (runs across dayjs / date-fns / luxon / moment)
  - A scenario using `clockConfig: new Date('2026-03-08T15:00:00.000Z')` that puts the adapter's `now` on the DST day (where the existing June 15 clock in `describeAdapters` wouldn't reach the bug). Covers both the unique-label assertion and clicking `"4 hours"` to set the value to 4 AM
- [ ] Both new assertions fail without the fix (`expected 11 to equal 12` for unique labels; "Found multiple elements with the role 'option' and name ..." when clicking a DST-affected hour) and pass with it
- [ ] Full `x-date-pickers` suite: 3248 pass, 0 fail
- [ ] Full `x-date-pickers-pro` suite: 986 pass, 0 fail
- [ ] `pnpm --filter "@mui/x-date-pickers*" run typescript` clean
- [ ] `pnpm prettier` clean

## Changelog

`[pickers]` Fix duplicate hour label in `MultiSectionDigitalClock` on DST spring-forward day.

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).